### PR TITLE
fix: pass secrets as action inputs instead of environment variables

### DIFF
--- a/.github/workflows/swe-agent-anthropic.yml
+++ b/.github/workflows/swe-agent-anthropic.yml
@@ -26,8 +26,7 @@ jobs:
           allowed_tools: 'str_replace_editor,bash,file_viewer,python_executor,git_tool'
           custom_instructions: 'Provide detailed explanations and consider edge cases.'
           fallback_models: 'claude-3-haiku-20240307,gpt-4o'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           # Fallback API key for OpenAI models
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          openai_api_key: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/swe-agent-azure.yml
+++ b/.github/workflows/swe-agent-azure.yml
@@ -26,8 +26,7 @@ jobs:
           allowed_tools: 'str_replace_editor,bash,file_viewer,python_executor,git_tool'
           custom_instructions: 'Follow enterprise security guidelines and coding standards.'
           workspace_timeout: '2400'  # 40 minutes for complex enterprise tasks
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
-          AZURE_OPENAI_ENDPOINT: ${{ vars.AZURE_OPENAI_ENDPOINT }}
-          AZURE_OPENAI_API_VERSION: ${{ vars.AZURE_OPENAI_API_VERSION }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          azure_openai_api_key: ${{ secrets.AZURE_OPENAI_API_KEY }}
+          azure_openai_endpoint: ${{ vars.AZURE_OPENAI_ENDPOINT }}
+          azure_openai_api_version: ${{ vars.AZURE_OPENAI_API_VERSION }}

--- a/.github/workflows/swe-agent-deepseek.yml
+++ b/.github/workflows/swe-agent-deepseek.yml
@@ -26,8 +26,7 @@ jobs:
           allowed_tools: 'str_replace_editor,bash,file_viewer,python_executor'
           custom_instructions: 'Focus on code quality and best practices.'
           fallback_models: 'deepseek/deepseek-coder,gpt-3.5-turbo'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          deepseek_api_key: ${{ secrets.DEEPSEEK_API_KEY }}
           # Fallback API key
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          openai_api_key: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/swe-agent-multi-provider.yml
+++ b/.github/workflows/swe-agent-multi-provider.yml
@@ -29,12 +29,11 @@ jobs:
           fallback_models: 'gpt-4o,deepseek/deepseek-chat,openrouter/anthropic/claude-3.5-sonnet,groq/llama2-70b-4096'
           workspace_timeout: '1800'
           debug_mode: 'false'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           # Primary provider
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           # Fallback providers
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
-          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+          openai_api_key: ${{ secrets.OPENAI_API_KEY }}
+          deepseek_api_key: ${{ secrets.DEEPSEEK_API_KEY }}
+          openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+          groq_api_key: ${{ secrets.GROQ_API_KEY }}

--- a/.github/workflows/swe-agent-openai.yml
+++ b/.github/workflows/swe-agent-openai.yml
@@ -25,6 +25,5 @@ jobs:
           max_cost: '5.00'
           allowed_tools: 'str_replace_editor,bash,file_viewer,python_executor'
           custom_instructions: 'Follow our coding standards and include tests for any changes.'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          openai_api_key: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/swe-agent-openrouter.yml
+++ b/.github/workflows/swe-agent-openrouter.yml
@@ -26,6 +26,5 @@ jobs:
           allowed_tools: 'str_replace_editor,bash,file_viewer,python_executor,git_tool'
           custom_instructions: 'Use the most appropriate model for the task complexity.'
           fallback_models: 'openrouter/openai/gpt-4,openrouter/meta-llama/llama-3-70b-instruct'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }}


### PR DESCRIPTION
## Summary
This PR fixes issue #32 where GitHub Actions workflow files were incorrectly passing secrets through environment variables instead of as action inputs.

## Changes
- Updated all workflow files in `.github/workflows/` to pass secrets through the `with` section as inputs
- Removed `env` sections that were incorrectly passing secrets
- Converted all API keys and GitHub token to use the proper input mechanism

## Files Changed
- `.github/workflows/swe-agent-anthropic.yml`
- `.github/workflows/swe-agent-azure.yml`
- `.github/workflows/swe-agent-deepseek.yml`
- `.github/workflows/swe-agent-multi-provider.yml`
- `.github/workflows/swe-agent-openai.yml`
- `.github/workflows/swe-agent-openrouter.yml`

## Test Plan
- [x] Verified no `env:` sections remain in workflow files
- [x] Confirmed all secrets are passed as action inputs matching the `action.yml` specification
- [x] All workflows now follow GitHub Actions best practices

Fixes #32

🤖 Generated with [Claude Code](https://claude.ai/code)